### PR TITLE
Fix commit author when publishing

### DIFF
--- a/src/main/kotlin/org/pkl/package_docs/PackageDocs.kt
+++ b/src/main/kotlin/org/pkl/package_docs/PackageDocs.kt
@@ -95,7 +95,16 @@ class PackageDocs(
       return
     }
 
-    runCommand(listOf("git", "commit", "--author=Pkl CI <pkl-oss@group.apple.com>", "-m", "Publish new documentation [skip ci]"), docsOutputDir)
+    runCommand(
+      listOf(
+        "git",
+        "commit",
+        "-c", "user.name=Pkl CI",
+        "-c", "user.email=pkl-oss@group.apple.com",
+        "-m", "Publish new documentation [skip ci]"
+      ),
+      docsOutputDir
+    )
     runCommand(listOf("git", "push", "origin", "www"), docsOutputDir)
   }
 


### PR DESCRIPTION
Setting the `--author` flag does not work if there is no global author.

See https://stackoverflow.com/a/73344026