### PR TITLE
Fix setting author when creating commit

### DIFF
--- a/src/main/kotlin/org/pkl/package_docs/PackageDocs.kt
+++ b/src/main/kotlin/org/pkl/package_docs/PackageDocs.kt
@@ -98,9 +98,9 @@ class PackageDocs(
     runCommand(
       listOf(
         "git",
-        "commit",
         "-c", "user.name=Pkl CI",
         "-c", "user.email=pkl-oss@group.apple.com",
+        "commit",
         "-m", "Publish new documentation [skip ci]"
       ),
       docsOutputDir


### PR DESCRIPTION
The `-m` flag needs to be set after the `commit` subcommand.