### PR TITLE
Pin versions of dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-pkl = "0.+"
+pkl = "0.25.+"
 ktor = "2.+"
 spotless = "6.25.0"
-kotlinxSerialization = "1.+"
+kotlinxSerialization = "1.6.+"
 kotlin = "1.+"
 
 [libraries]


### PR DESCRIPTION
Fix an issue where the build is broken due to incompatible dependencies between kotlinx serialization and kotlin.

Also, pin Pkl to 0.25.+ because 0.26 will introduce breaking changes that needs to be manually fixed later.