### PR TITLE
Make Gradle refresh dependencies on build

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -52,7 +52,7 @@ jobs {
     steps {
       "checkout"
       new RunStep {
-        command = "./gradlew generateAndPublishDocs"
+        command = "./gradlew generateAndPublishDocs --refresh-dependencies"
       }
     }
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - checkout
     - run:
-        command: ./gradlew generateAndPublishDocs
+        command: ./gradlew generateAndPublishDocs --refresh-dependencies
     docker:
     - image: cimg/openjdk:17.0
   trigger-docsite-build:


### PR DESCRIPTION
Address an issue where the build doesn't pick up new versions of the Pkl standard library.

Docs: https://docs.gradle.org/current/userguide/dependency_caching.html#sec:refreshing-dependencies